### PR TITLE
Bump to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: '5'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: 'terminal'

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "homepage": "https://github.com/haythem/public-ip#readme",
   "dependencies": {
-    "@actions/core": "1.10.0",
-    "@actions/http-client": "2.0.1"
+    "@actions/core": "1.10.1",
+    "@actions/http-client": "2.2.1"
   },
   "devDependencies": {
     "@types/jest": "29.2.0",


### PR DESCRIPTION
# Why

This action is being used on some of our github actions workflows and as it stands it's running on a deprecated node runner version, 16. Github throws a warning that this runner is deprecated and asking to upgrade the version. This PR accomplishes that.

# Version Updates
This PR updates the runner on `action.yml` to `node20`.
It also bumps `core` to `1.10.1` and `http-client` to `2.2.1`.